### PR TITLE
Added strip mode to allow loader chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,12 @@ module.exports = function (source, testOpts) {
   if (opts.mode === 'style') {
     return styles.join('\n')
   }
+
+  // strip mode
+  if (opts.mode === 'strip') {
+    return unstyledTag
+  }
+
   // normal mode
   var requireStr = 'require("!!style!css' + loader + '!riotjs-style-plus-loader?style!./' + opts.filename + '")'
   return [requireStr, unstyledTag].join('\n')


### PR DESCRIPTION
This small addition adds a strip mode to allow more flexibie chaining in your webpack configuration. 

An example would be if you want to extract and combine all styling into an external stylesheet and remove all the css from the javascript bundle. Something like this (using multiloader to split the loader chain):

``` javascript
loader: MultiLoader(
  ExtractTextPlugin.extract("style", "css!stylus!riotjs-style-plus?style"),
  "riotjs!riotjs-style-plus?strip"
)
```

So the extractTextPlugin gets the styles to put into an external css file. The ?strip causes them to be removed from the output going to the riotjs loader (i.e. it strips the styling)
